### PR TITLE
Revise website documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -36,6 +36,12 @@ resource "flexibleengine_compute_instance_v2" "test-server" {
 
 The following arguments are supported:
 
+* `access_key` - (Optional) The access key of the FlexibleEngine cloud to use.
+  If omitted, the `OS_ACCESS_KEY` environment variable is used.
+
+* `secret_key` - (Optional) The secret key of the FlexibleEngine cloud to use.
+  If omitted, the `OS_SECRET_KEY` environment variable is used.
+
 * `auth_url` - (Required) The Identity authentication URL. If omitted, the
   `OS_AUTH_URL` environment variable is used.
 

--- a/website/docs/r/as_configuration_v1.html.markdown
+++ b/website/docs/r/as_configuration_v1.html.markdown
@@ -124,7 +124,7 @@ The `disk` block supports:
 
 The `personality` block supports:
 
-* `file` - (Required) The absolute path of the destination file.
+* `path` - (Required) The absolute path of the destination file.
 
 * `contents` - (Required) The content of the injected file, which must be encoded with base64.
 

--- a/website/docs/r/fw_policy_v2.html.markdown
+++ b/website/docs/r/fw_policy_v2.html.markdown
@@ -71,6 +71,10 @@ The following arguments are supported:
     `shared` status of an existing firewall policy. Only administrative users
     can specify if the policy should be shared.
 
+* `tenant_id` - (Optional) The owner of the firewall policy. Required if admin wants
+    to create a firewall policy for another tenant. Changing this creates a new
+    firewall policy.
+
 * `value_specs` - (Optional) Map of additional options.
 
 ## Attributes Reference
@@ -82,6 +86,7 @@ The following attributes are exported:
 * `description` - See Argument Reference above.
 * `audited` - See Argument Reference above.
 * `shared` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.
 
 ## Import
 

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -50,9 +50,6 @@ The following arguments are supported:
 
 * `description` - (Optional) Human-readable description for the Listener.
 
-* `connection_limit` - (Optional) The maximum number of connections allowed
-    for the Listener.
-
 * `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
     container which stores TLS information. This is required if the protocol
     is `TERMINATED_HTTPS`. See
@@ -78,7 +75,6 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `default_port_id` - See Argument Reference above.
 * `description` - See Argument Reference above.
-* `connection_limit` - See Argument Reference above.
 * `default_tls_container_ref` - See Argument Reference above.
 * `sni_container_refs` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.


### PR DESCRIPTION
1. Adds 'access_key' and 'secret_key' to FlexibleEngine provider page
2. Adds 'tenant_id' variable in fw_policy_v2 docs
3. Correct variable name error in as_configuration_v1 page
4. Remove unsupported 'connection_limit' varaible in lb_listener_v2

Partially address issue #5