### PR TITLE
Add missing website docs

### DIFF
--- a/website/docs/d/s3_bucket_object.html.markdown
+++ b/website/docs/d/s3_bucket_object.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_s3_bucket_object"
+sidebar_current: "docs-flexibleengine-datasource-s3-bucket-object"
+description: |-
+    Provides metadata and optionally content of an S3 object
+---
+
+# flexibleengine\_s3\_bucket\_object
+
+The S3 object data source allows access to the metadata and
+_optionally_ (see below) content of an object stored inside S3 bucket.
+
+~> **Note:** The content of an object (`body` field) is available only for objects which have a human-readable `Content-Type` (`text/*` and `application/json`). This is to prevent printing unsafe characters and potentially downloading large amount of data which would be thrown away in favour of metadata.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_s3_bucket_object" "b" {
+  bucket = "my-test-bucket"
+  key    = "hello-world.zip"
+}
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) The name of the bucket to read the object from
+* `key` - (Required) The full path to the object inside the bucket
+* `range` - (Optional) Obtains the specified range bytes of an object. The value is a range starting from 0 to maximum object length minus one. If the range is invalid, all object data is returned.
+* `version_id` - (Optional) Specific version ID of the object returned (defaults to latest version)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `body` - Object data (see **limitations above** to understand cases in which this field is actually available)
+* `cache_control` - Specifies caching behavior along the request/reply chain.
+* `content_disposition` - Specifies presentational information for the object.
+* `content_encoding` - Specifies what content encodings have been applied to the object and thus what decoding mechanisms must be applied to obtain the media-type referenced by the Content-Type header field.
+* `content_language` - The language the content is in.
+* `content_length` - Size of the body in bytes.
+* `content_type` - A standard MIME type describing the format of the object data.
+* `etag` - [ETag](https://en.wikipedia.org/wiki/HTTP_ETag) generated for the object (an MD5 sum of the object content in case it's not encrypted)
+* `expiration` - If the object expiration is configured, the field includes this header. It includes the expiry-date and rule-id key value pairs providing object expiration information. The value of the rule-id is URL encoded.
+* `expires` - The date and time at which the object is no longer cacheable.
+* `last_modified` - Last modified date of the object in RFC1123 format (e.g. `Mon, 02 Jan 2006 15:04:05 MST`)
+* `metadata` - A map of metadata stored with the object in S3
+* `server_side_encryption` - If the object is stored using server-side encryption (KMS or Amazon S3-managed encryption key), this field includes the chosen encryption and algorithm used.
+* `sse_kms_key_id` - If present, specifies the ID of the Key Management Service (KMS) master encryption key that was used for the object.
+* `website_redirect_location` - If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. S3 stores the value of this header in the object metadata.

--- a/website/docs/r/elb_backend.html.markdown
+++ b/website/docs/r/elb_backend.html.markdown
@@ -1,0 +1,75 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_elb_backend"
+sidebar_current: "docs-flexibleengine-resource-elb-backend"
+description: |-
+  Manages an elastic loadbalancer backend resource within FlexibleEngine.
+---
+
+# flexibleengine\_elb\_backend
+
+Manages an elastic loadbalancer backend resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_elb_loadbalancer" "elb" {
+  name = "elb"
+  type = "External"
+  description = "test elb"
+  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  admin_state_up = 1
+  bandwidth = 5
+}
+
+resource "flexibleengine_elb_listener" "listener" {
+  name = "test-elb-listener"
+  description = "great listener"
+  protocol = "TCP"
+  backend_protocol = "TCP"
+  protocol_port = 12345
+  backend_port = 8080
+  lb_algorithm = "roundrobin"
+  loadbalancer_id = "${flexibleengine_elb_loadbalancer.elb.id}"
+  timeouts {
+	create = "5m"
+	update = "5m"
+	delete = "5m"
+  }
+}
+
+resource "flexibleengine_elb_backend" "backend" {
+  address = "192.168.0.211"
+  listener_id = "${flexibleengine_elb_listener.listener.id}"
+  server_id = "8f7a32f1-f66c-4d13-9b17-3a13f9f0bb8d"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `listener_id` - (Required) Specifies the listener ID.
+
+* `server_id` - (Required) Specifies the backend member ID.
+
+* `address` - (Required) Specifies the private IP address of the backend member.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `listener_id` - See Argument Reference above.
+* `server_id` - See Argument Reference above.
+* `address` - See Argument Reference above.
+* `server_address` - Specifies the floating IP address assigned to the backend member.
+* `id` - Specifies the backend member ID.
+* `status` - Specifies the backend ECS status. The value is ACTIVE, PENDING,
+    or ERROR.
+* `health_status` - Specifies the health check status. The value is NORMAL,
+    ABNORMAL, or UNAVAILABLE.
+* `update_time` - Specifies the time when information about the backend member
+    was updated.
+* `create_time` - Specifies the time when the backend member was created.
+* `server_name` - Specifies the backend member name.
+* `listeners` - Specifies the listener to which the backend member belongs.

--- a/website/docs/r/elb_health.html.markdown
+++ b/website/docs/r/elb_health.html.markdown
@@ -1,0 +1,107 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_elb_health"
+sidebar_current: "docs-flexibleengine-resource-elb-health"
+description: |-
+  Manages an elastic loadbalancer health resource within FlexibleEngine.
+---
+
+# flexibleengine\_elb\_health
+
+Manages an elastic loadbalancer health resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_elb_loadbalancer" "elb" {
+  name = "elb"
+  type = "External"
+  description = "test elb"
+  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  admin_state_up = 1
+  bandwidth = 5
+}
+
+resource "flexibleengine_elb_listener" "listener" {
+  name = "test-elb-listener"
+  description = "great listener"
+  protocol = "TCP"
+  backend_protocol = "TCP"
+  protocol_port = 12345
+  backend_port = 8080
+  lb_algorithm = "roundrobin"
+  loadbalancer_id = "${flexibleengine_elb_loadbalancer.elb.id}"
+  timeouts {
+	create = "5m"
+	update = "5m"
+	delete = "5m"
+  }
+}
+
+resource "flexibleengine_elb_health" "healthcheck" {
+  listener_id = "${flexibleengine_elb_listener.listener.id}"
+  healthcheck_protocol = "TCP"
+  healthcheck_connect_porta = 22
+  healthy_threshold = 5
+  healthcheck_timeout = 25
+  healthcheck_interval = 3
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the elb health. If
+    omitted, the `region` argument of the provider is used. Changing this
+    creates a new elb health.
+
+* `listener_id` - (Required) Specifies the ID of the listener to which the health
+    check task belongs.
+
+* `healthcheck_protocol` - (Optional) Specifies the protocol used for the health
+    check. The value can be HTTP or TCP (case-insensitive).
+
+* `healthcheck_uri` - (Optional) Specifies the URI for health check. This parameter
+    is valid when healthcheck_ protocol is HTTP. The value is a string of 1 to 80
+    characters that must start with a slash (/) and can only contain letters, digits,
+    and special characters, such as -/.%?#&.
+
+* `healthcheck_connect_port` - (Optional) Specifies the port used for the health
+    check. The value ranges from 1 to 65535.
+
+* `healthy_threshold` - (Optional) Specifies the threshold at which the health
+    check result is success, that is, the number of consecutive successful health
+    checks when the health check result of the backend server changes from fail
+    to success. The value ranges from 1 to 10.
+
+* `unhealthy_threshold` - (Optional) Specifies the threshold at which the health
+    check result is fail, that is, the number of consecutive failed health checks
+    when the health check result of the backend server changes from success to fail.
+    The value ranges from 1 to 10.
+
+* `healthcheck_timeout` - (Optional) Specifies the maximum timeout duration
+    (s) for the health check. The value ranges from 1 to 50.
+
+* `healthcheck_interval` - (Optional) Specifies the maximum interval (s) for
+    health check. The value ranges from 1 to 5.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `listener_id` - See Argument Reference above.
+* `healthcheck_protocol` - See Argument Reference above.
+* `healthcheck_uri` - See Argument Reference above.
+* `healthcheck_connect_port` - See Argument Reference above.
+* `healthy_threshold` - See Argument Reference above.
+* `unhealthy_threshold` - See Argument Reference above.
+* `healthcheck_timeout` - See Argument Reference above.
+* `healthcheck_interval` - See Argument Reference above.
+* `id` - Specifies the health check task ID.

--- a/website/docs/r/elb_listener.html.markdown
+++ b/website/docs/r/elb_listener.html.markdown
@@ -1,0 +1,149 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_elb_listener"
+sidebar_current: "docs-flexibleengine-resource-elb-listener"
+description: |-
+  Manages an elastic loadbalancer listener resource within FlexibleEngine.
+---
+
+# flexibleengine\_elb\_listener
+
+Manages an elastic loadbalancer listener resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_elb_loadbalancer" "elb" {
+  name = "elb"
+  type = "External"
+  description = "test elb"
+  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  admin_state_up = 1
+  bandwidth = 5
+}
+
+resource "flexibleengine_elb_listener" "listener" {
+  name = "test-elb-listener"
+  description = "great listener"
+  protocol = "TCP"
+  backend_protocol = "TCP"
+  protocol_port = 12345
+  backend_port = 8080
+  lb_algorithm = "roundrobin"
+  loadbalancer_id = "${flexibleengine_elb_loadbalancer.elb.id}"
+  timeouts {
+	create = "5m"
+	update = "5m"
+	delete = "5m"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the elb listener. If
+    omitted, the `region` argument of the provider is used. Changing this
+    creates a new elb listener.
+
+* `name` - (Required) Specifies the load balancer name. The name is a string
+    of 1 to 64 characters that consist of letters, digits, underscores (_), and
+    hyphens (-).
+
+* `description` - (Optional) Provides supplementary information about the listener.
+    The value is a string of 0 to 128 characters and cannot be <>.
+
+* `loadbalancer_id` - (Required) Specifies the ID of the load balancer to which
+    the listener belongs.
+
+* `protocol` - (Required) Specifies the listening protocol used for layer 4
+    or 7. The value can be HTTP, TCP, HTTPS, or UDP.
+
+* `protocol_port` - (Required) Specifies the listening port. The value ranges from 1
+    to 65535.
+
+* `backend_protocol` - (Required) Specifies the backend protocol. If the value
+    of protocol is UDP, the value of this parameter can only be UDP. The value can
+    be HTTP, TCP, or UDP.
+
+* `backend_port` - (Required) Specifies the backend port. The value ranges from
+    1 to 65535.
+
+* `lb_algorithm` - (Required) Specifies the load balancing algorithm for the
+    listener. The value can be roundrobin, leastconn, or source.
+
+* `session_sticky` - (Optional) Specifies whether to enable sticky session.
+    The value can be true or false. The Sticky session is enabled when the value
+    is true, and is disabled when the value is false. If the value of protocol is
+    HTTP, HTTPS, or TCP, and the value of lb_algorithm is not roundrobin, the value
+    of this parameter can only be false.
+
+* `sticky_session_type` - (Optional) Specifies the cookie processing method.
+    The value is insert. insert indicates that the cookie is inserted by the load
+    balancer. This parameter is valid when protocol is set to HTTP, and session_sticky
+    to true. The default value is insert. This parameter is invalid when protocol
+    is set to TCP or UDP, which means the parameter is empty.
+
+* `cookie_timeout` - (Optional) Specifies the cookie timeout period (minutes).
+    This parameter is valid when protocol is set to HTTP, session_sticky to true,
+    and sticky_session_type to insert. This parameter is invalid when protocol is
+    set to TCP or UDP. The value ranges from 1 to 1440.
+
+* `tcp_timeout` - (Optional) Specifies the TCP timeout period (minutes). This
+    parameter is valid when protocol is set to TCP. The value ranges from 1 to 5.
+
+* `tcp_draining` - (Optional) Specifies whether to maintain the TCP connection
+    to the backend ECS after the ECS is deleted. This parameter is valid when protocol
+    is set to TCP. The value can be true or false.
+
+* `tcp_draining_timeout` - (Optional) Specifies the timeout duration (minutes)
+    for the TCP connection to the backend ECS after the ECS is deleted. This parameter
+    is valid when protocol is set to TCP, and tcp_draining to true. The value ranges
+    from 0 to 60.
+
+* `certificate_id` - (Optional) Specifies the ID of the SSL certificate used
+    for security authentication when HTTPS is used to make API calls. This parameter
+    is mandatory if the value of protocol is HTTPS. The value can be obtained by
+    viewing the details of the SSL certificate.
+
+* `udp_timeout` - (Optional) Specifies the UDP timeout duration (minutes). This
+    parameter is valid when protocol is set to UDP. The value ranges from 1 to 1440.
+
+* `ssl_protocols` - (Optional) Specifies the SSL protocol standard supported
+    by a tracker, which is used for enabling specified encryption protocols. This
+    parameter is valid only when the value of protocol is set to HTTPS. The value
+    is TLSv1.2 or TLSv1.2 TLSv1.1 TLSv1. The default value is TLSv1.2.
+
+* `ssl_ciphers` - (Optional) Specifies the cipher suite of an encryption protocol.
+    This parameter is valid only when the value of protocol is set to HTTPS. The
+    value is Default, Extended, or Strict. The default value is Default. The value
+    can only be set to Extended if the value of ssl_protocols is set to TLSv1.2
+    TLSv1.1 TLSv1.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `loadbalancer_id` - See Argument Reference above.
+* `protocol` - See Argument Reference above.
+* `protocol_port` - See Argument Reference above.
+* `backend_protocol` - See Argument Reference above.
+* `backend_port` - See Argument Reference above.
+* `lb_algorithm` - See Argument Reference above.
+* `session_sticky` - See Argument Reference above.
+* `sticky_session_type` - See Argument Reference above.
+* `cookie_timeout` - See Argument Reference above.
+* `tcp_timeout` - See Argument Reference above.
+* `tcp_draining` - See Argument Reference above.
+* `tcp_draining_timeout` - See Argument Reference above.
+* `certificate_id` - See Argument Reference above.
+* `udp_timeout` - See Argument Reference above.
+* `ssl_protocols` - See Argument Reference above.
+* `ssl_ciphers` - See Argument Reference above.
+* `id` - Specifies the listener ID.
+* `admin_state_up` - Specifies the status of the load balancer. Value range:
+    false: The load balancer is disabled. true: The load balancer runs properly.

--- a/website/docs/r/elb_loadbalancer.html.markdown
+++ b/website/docs/r/elb_loadbalancer.html.markdown
@@ -1,0 +1,95 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_elb_loadbalancer"
+sidebar_current: "docs-flexibleengine-resource-elb-loadbalancer"
+description: |-
+  Manages an elastic loadbalancer resource within FlexibleEngine.
+---
+
+# flexibleengine\_elb\_loadbalancer
+
+Manages an elastic loadbalancer resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_elb_loadbalancer" "elb" {
+  name = "elb"
+  type = "External"
+  description = "test elb"
+  vpc_id = "e346dc4a-d9a6-46f4-90df-10153626076e"
+  admin_state_up = 1
+  bandwidth = 5
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the loadbalancer. If
+    omitted, the `region` argument of the provider is used. Changing this
+    creates a new loadbalancer.
+
+* `name` - (Required) Specifies the load balancer name. The name is a string
+    of 1 to 64 characters that consist of letters, digits, underscores (_),
+    and hyphens (-).
+
+* `description` - (Optional) Provides supplementary information about the
+    listener. The value is a string of 0 to 128 characters and cannot be <>.
+
+* `vpc_id` - (Required) Specifies the VPC ID.
+
+* `bandwidth` - (Optional) Specifies the bandwidth (Mbit/s). This parameter
+    is mandatory when type is set to External, and it is invalid when type
+    is set to Internal. The value ranges from 1 to 300.
+
+* `type` - (Required) Specifies the load balancer type. The value can be
+    Internal or External.
+
+* `admin_state_up` - (Required) Specifies the status of the load balancer.
+    Value range: 0 or false: indicates that the load balancer is stopped. Only
+    tenants are allowed to enter these two values. 1 or true: indicates that
+    the load balancer is running properly. 2 or false: indicates that the load
+    balancer is frozen. Only tenants are allowed to enter these two values.
+
+* `vip_subnet_id` - (Optional) Specifies the ID of the private network
+    to be added. This parameter is mandatory when type is set to Internal,
+    and it is invalid when type is set to External.
+
+* `az` - (Optional) Specifies the ID of the availability zone (AZ). This
+    parameter is mandatory when type is set to Internal, and it is invalid
+    when type is set to External.
+
+* `security_group_id` - (Optional) Specifies the security group ID. The
+    value is a string of 1 to 200 characters that consists of uppercase and
+    lowercase letters, digits, and hyphens (-). This parameter is mandatory
+    only when type is set to Internal.
+
+* `vip_address` - (Optional) Specifies the IP address provided by ELB.
+    When type is set to External, the value of this parameter is the elastic
+    IP address. When type is set to Internal, the value of this parameter is
+    the private network IP address. You can select an existing elastic IP address
+    and create a public network load balancer. When this parameter is configured,
+    parameter bandwidth is invalid.
+
+* `tenantid` - (Optional) Specifies the tenant ID. This parameter is mandatory
+    only when type is set to Internal.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `description` - See Argument Reference above.
+* `vpc_id` - See Argument Reference above.
+* `bandwidth` - See Argument Reference above.
+* `type` - See Argument Reference above.
+* `admin_state_up` - See Argument Reference above.
+* `vip_subnet_id` - See Argument Reference above.
+* `az` - See Argument Reference above.
+* `security_group_id` - See Argument Reference above.
+* `vip_address` - See Argument Reference above.
+* `tenantid` - See Argument Reference above.
+* `id` - Specifies the load balancer ID.

--- a/website/docs/r/networking_network_v2.html.markdown
+++ b/website/docs/r/networking_network_v2.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 The `segments` block supports:
 
-* `physical_network` - The phisical network where this network is implemented.
+* `physical_network` - The physical network where this network is implemented.
 * `segmentation_id` - An isolated segment on the physical network.
 * `network_type` - The type of physical network.
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -71,7 +71,6 @@ The following arguments are supported:
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.
 This attribute is not compatible with `kms_key_id`.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".
-* `tags` - (Optional) A mapping of tags to assign to the object.
 
 Either `source` or `content` must be provided to specify the bucket content.
 These two arguments are mutually-exclusive.

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -22,6 +22,9 @@
             <li<%= sidebar_current("docs-flexibleengine-datasource-rds-flavors-v1") %>>
               <a href="/docs/providers/flexibleengine/d/rds_flavors_v1.html">flexibleengine_rds_flavors_v1</a>
             </li>
+            <li<%= sidebar_current("docs-flexibleengine-datasource-s3-bucket-object") %>>
+              <a href="/docs/providers/flexibleengine/d/s3_bucket_object.html">flexibleengine_s3_bucket_object</a>
+            </li>
           </ul>
         </li>
 
@@ -156,6 +159,24 @@
             </li>
             <li<%= sidebar_current("docs-flexibleengine-resource-lb-monitor-v2") %>>
               <a href="/docs/providers/flexibleengine/r/lb_monitor_v2.html">flexibleengine_lb_monitor_v2</a>
+            </li>
+          </ul>
+        </li>
+
+        <li<%= sidebar_current("docs-flexibleengine-resource-elb") %>>
+          <a href="#">Elastic Load Balancer Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-flexibleengine-resource-elb-loadbalancer") %>>
+              <a href="/docs/providers/flexibleengine/r/elb_loadbalancer.html">flexibleengine_elb_loadbalancer</a>
+            </li>
+            <li<%= sidebar_current("docs-flexibleengine-resource-elb-listener") %>>
+              <a href="/docs/providers/flexibleengine/r/elb_listener.html">flexibleengine_elb_listener</a>
+            </li>
+            <li<%= sidebar_current("docs-flexibleengine-resource-elb-health") %>>
+              <a href="/docs/providers/flexibleengine/r/elb_health.html">flexibleengine_elb_health</a>
+            </li>
+            <li<%= sidebar_current("docs-flexibleengine-resource-elb-backend") %>>
+              <a href="/docs/providers/flexibleengine/r/elb_backend.html">flexibleengine_elb_backend</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This adds the missing documentation for resources and data source:

resource_flexibleengine_elb_backend
resource_flexibleengine_elb_health
resource_flexibleengine_elb_listener
resource_flexibleengine_elb_loadbalancer
data_source_flexibleengine_s3_bucket_object

Partially address #5 